### PR TITLE
Fixed a problem when no components have loadProps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,6 @@
+## [HEAD]
+
+- Fixed a problem when no components have loadProps ([#2])
+
+[HEAD]: https://github.com/rackt/async-props/compare/latest...HEAD
+[#2]: https://github.com/rackt/async-props/pull/2

--- a/modules/AsyncProps.js
+++ b/modules/AsyncProps.js
@@ -40,6 +40,11 @@ function loadAsyncProps(components, params, cb) {
       cb(null, { propsArray, componentsArray })
   }
 
+  // If there is no components we should resolve directly
+  if (needToLoadCounter === 0) {
+    return maybeFinish()
+  }
+
   components.forEach((Component, index) => {
     Component.loadProps(params, (error, props) => {
       needToLoadCounter--

--- a/modules/__tests__/AsyncProps-test.js
+++ b/modules/__tests__/AsyncProps-test.js
@@ -67,6 +67,43 @@ class Cereal extends React.Component {
   }
 }
 
+class NoLoadProps extends React.Component {
+  render() {
+    return <h1>No loadProps!</h1>
+  }
+}
+
+class AppNoLoadProps extends React.Component {
+  static setAssertions(assertions) {
+    this.assertions = assertions
+  }
+
+  static clearAssertions() {
+    this.assertions = null
+  }
+
+  componentDidMount() {
+    this.assert()
+  }
+
+  componentDidUpdate() {
+    this.assert()
+  }
+
+  assert() {
+    if (this.constructor.assertions)
+      this.constructor.assertions()
+  }
+
+  render() {
+    return (
+      <div>
+        {this.props.children || <div>no child</div>}
+      </div>
+    )
+  }
+}
+
 const routes = {
   path: '/',
   component: App,
@@ -224,6 +261,41 @@ describe('AsyncProps', () => {
         />
       ), div, next)
     })
+
+    it('renders correctly when no components have loadProps', (done) => {
+      const history = createHistory('/')
+
+      const noLoadPropsRoutes = {
+        path: '/',
+        component: AppNoLoadProps,
+        childRoutes: [ {
+          path: 'update',
+          component: NoLoadProps
+        } ]
+      }
+
+      const next = execNext([
+        () => {},
+        () => {
+          expect(div.textContent).toContain('no child')
+          history.pushState(null, '/update')
+        },
+        () => {
+          () => expect(div.textContent).toContain('No loadProps!')
+        },
+        done
+      ])
+
+      AppNoLoadProps.setAssertions(next)
+
+      render((
+        <Router
+          history={history}
+          RoutingContext={AsyncProps}
+          routes={noLoadPropsRoutes}
+        />
+      ), div, next)
+    })
   })
 
   describe('server rendering', () => {
@@ -238,6 +310,16 @@ describe('AsyncProps', () => {
 
     beforeEach(() => window.__ASYNC_PROPS__ = JSON.stringify([ DATA ]))
     afterEach(() => delete window.__ASYNC_PROPS__ )
+
+    it('renders correctly when no components have loadProps', (done) => {
+      const noLoadPropsRoutes = {
+        path: '/',
+        component: AppNoLoadProps
+      }
+      match({ routes: noLoadPropsRoutes, location: '/' }, (err, redirect, renderProps) => {
+        loadPropsOnServer(renderProps, done)
+      })
+    })
 
     it('renders synchronously with props from hydration', () => {
       const html = renderToString(


### PR DESCRIPTION
This PR fixes a problem when no components have loadProps. I have also added two tests that without the fix in this PR fails.

I'm not sure if I made the correct modifications in the `CHANGES.md` since it was empty with no prior releases. I'm happy to change this if it should be done in some other way.
