### PR TITLE
loadAsyncProps never fires callback

### DIFF
--- a/modules/AsyncProps.js
+++ b/modules/AsyncProps.js
@@ -48,6 +48,7 @@ function loadAsyncProps(components, params, cb) {
       maybeFinish()
     })
   })
+  maybeFinish()
 }
 
 function lookupPropsForComponent(Component, propsAndComponents) {


### PR DESCRIPTION
When the flattened components that are passed in is an empty array `maybeFinish` is never called which means the callback is never fired.
