### PR TITLE
Only parse __ASYNC_PROPS__ if it's a string

### DIFF
--- a/modules/AsyncProps.js
+++ b/modules/AsyncProps.js
@@ -132,7 +132,9 @@ export function loadPropsOnServer({ components, params }, cb) {
 function hydrate(props) {
   if (typeof __ASYNC_PROPS__ !== 'undefined')
     return {
-      propsArray: __ASYNC_PROPS__,
+      propsArray: typeof __ASYNC_PROPS__ === 'string'
+        ? JSON.parse(__ASYNC_PROPS__)
+        : __ASYNC_PROPS__,
       componentsArray: filterAndFlattenComponents(props.components)
     }
   else


### PR DESCRIPTION
I came across this issue when I rendered `stringText` through a react component, `__ASYNC_PROPS__` wasn’t stringified, so when trying to parse it on `hydrate` it threw an error. Here's some basic checking to only parse it if it's a string.
