### PR TITLE
pass on error in `loadAsyncProps`

### DIFF
--- a/modules/AsyncProps.js
+++ b/modules/AsyncProps.js
@@ -35,7 +35,13 @@ function loadAsyncProps(components, params, cb) {
   let propsArray = []
   let needToLoadCounter = components.length
 
-  const maybeFinish = () => {
+  const maybeFinish = (err) => {
+    if ( err ) {
+      // error occured, stop executing
+      cb(err);
+      return;
+    }
+
     if (needToLoadCounter === 0)
       cb(null, { propsArray, componentsArray })
   }
@@ -50,7 +56,7 @@ function loadAsyncProps(components, params, cb) {
       needToLoadCounter--
       propsArray[index] = props
       componentsArray[index] = Component
-      maybeFinish()
+      maybeFinish(error)
     })
   })
 }


### PR DESCRIPTION
Before this, if a `loadProps` handler called the done callback with an error,
the error was not passed on to `loadPropsOnServer` or on the client. Now it is.
