### PR TITLE
Filter routes without component

### DIFF
--- a/modules/AsyncProps.js
+++ b/modules/AsyncProps.js
@@ -23,7 +23,7 @@ function eachComponents(components, iterator) {
 function filterAndFlattenComponents(components) {
   var flattened = []
   eachComponents(components, (Component) => {
-    if (Component.loadProps)
+    if (Component && Component.loadProps)
       flattened.push(Component)
   })
   return flattened


### PR DESCRIPTION
This fixes a reference error when a route is configured without a component.

For example, when using an empty route in combination with an IndexRoute to get a proper path hierarchy.
