### PR TITLE
update to babel 6, add semicolons after static props to conform

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,7 @@
 {
-  "stage": 0,
-  "loose": "all",
+  "presets": [
+    "es2015",
+    "stage-0",
+    "react"
+  ]
 }
-

--- a/modules/AsyncProps.js
+++ b/modules/AsyncProps.js
@@ -145,11 +145,11 @@ class AsyncPropsContainer extends React.Component {
   static propTypes = {
     Component: func.isRequired,
     routerProps: object.isRequired
-  }
+  };
 
   static contextTypes = {
     asyncProps: object.isRequired
-  }
+  };
 
   componentWillReceiveProps(nextProps) {
     const paramsChanged = !shallowEqual(nextProps.routerProps.routeParams,
@@ -181,7 +181,7 @@ class AsyncProps extends React.Component {
 
   static childContextTypes = {
     asyncProps: object
-  }
+  };
 
   static propTypes = {
     components: array.isRequired,
@@ -193,7 +193,7 @@ class AsyncProps extends React.Component {
     // server rendering
     propsArray: array,
     componentsArray: array
-  }
+  };
 
   static defaultProps = {
     onError(err) {
@@ -207,7 +207,7 @@ class AsyncProps extends React.Component {
     render(props) {
       return <RouterContext {...props} createElement={createElement}/>
     }
-  }
+  };
 
   constructor(props, context) {
     super(props, context)

--- a/package.json
+++ b/package.json
@@ -26,10 +26,12 @@
     "react-router": "2.0.0-rc4"
   },
   "devDependencies": {
-    "babel": "^5.8.34",
-    "babel-core": "^5.8.34",
+    "babel-cli": "^6.4.0",
     "babel-eslint": "^3.1.23",
-    "babel-loader": "^5.4.0",
+    "babel-loader": "~6.2.1",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-react": "^6.3.13",
+    "babel-preset-stage-0": "^6.3.13",
     "eslint": "1.4.1",
     "eslint-config-rackt": "1.0.0",
     "eslint-plugin-react": "3.3.2",


### PR DESCRIPTION
Note that currently with the latest on npm 0.2.2, you'll get the following warning:

```
→ npm install --save async-props

npm WARN EPEERINVALID async-props@0.2.2 requires a peer of react-router@^1.0.0 but none was installed.
```

And if setting your dependency to `rackt/async-props` you'll get another error if you're on Babel 6:

```
d4: ~/code/universal-redux (async-props)
→ npmi

> async-props@0.2.2 postinstall /Users/d4/code/universal-redux/node_modules/async-props
> node ./npm-scripts/postinstall.js


> async-props@0.2.2 build /Users/d4/code/universal-redux/node_modules/async-props
> babel ./modules --stage 0 --loose all -d lib --ignore '__tests__'

SyntaxError: modules/AsyncProps.js: A semicolon is required after a class property (148:3)
  146 |     Component: func.isRequired,
  147 |     routerProps: object.isRequired
> 148 |   }
      |    ^
  149 |
  150 |   static contextTypes = {
  151 |     asyncProps: object.isRequired
```

These changes update the core library to use Babel 6 for compilation and fix the static props error, but until another npm publish happens you can set your dependency to `bdefore/async-props#babel6-support`
