### PR TITLE
fix for state not updating on route change

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ render((
 
 ```js
 import { renderToString } from 'react-dom/server'
-import { match, RoutingContext } from 'react-router'
+import { match, RouterContext } from 'react-router'
 import AsyncProps, { loadPropsOnServer } from 'async-props'
 
 app.get('*', (req, res) => {
@@ -92,7 +92,7 @@ app.get('*', (req, res) => {
     // 1. load the props
     loadPropsOnServer(renderProps, (err, asyncProps, scriptTag) => {
 
-      // 2. use `AsyncProps` instead of `RoutingContext` and pass it
+      // 2. use `AsyncProps` instead of `RouterContext` and pass it
       //    `renderProps` and `asyncProps`
       const appHTML = renderToString(
         <AsyncProps {...renderProps} {...asyncProps} />

--- a/modules/AsyncProps.js
+++ b/modules/AsyncProps.js
@@ -259,7 +259,7 @@ class AsyncProps extends React.Component {
     }
 
     if (components.length > 0)
-      this.loadAsyncProps(components, nextProps.params, nextProps.location)
+      this.loadAsyncProps(components, nextProps.params, nextProps.location, { force: true })
   }
 
   handleError(cb) {


### PR DESCRIPTION
Turns out, this was the problem. When the route changes, the update is not being forced. Also removed `RoutingContext` from the readme for you.
