### PR TITLE
Add Location to loadProps

### DIFF
--- a/modules/AsyncProps.js
+++ b/modules/AsyncProps.js
@@ -29,7 +29,7 @@ function filterAndFlattenComponents(components) {
   return flattened
 }
 
-function loadAsyncProps(components, params, cb) {
+function loadAsyncProps(components, route, cb) {
   // flatten the multi-component routes
   let componentsArray = []
   let propsArray = []
@@ -46,7 +46,7 @@ function loadAsyncProps(components, params, cb) {
   }
 
   components.forEach((Component, index) => {
-    Component.loadProps(params, (error, props) => {
+    Component.loadProps(route, (error, props) => {
       needToLoadCounter--
       propsArray[index] = props
       componentsArray[index] = Component
@@ -112,10 +112,10 @@ function createElement(Component, props) {
     return <Component {...props}/>
 }
 
-export function loadPropsOnServer({ components, params }, cb) {
+export function loadPropsOnServer({ components, params, location }, cb) {
   loadAsyncProps(
     filterAndFlattenComponents(components),
-    params,
+    { params, location },
     (err, propsAndComponents) => {
       if (err) {
         cb(err)


### PR DESCRIPTION
This would allow you to do: 

``` js
static loadProps(route, cb) {
    console.log(route.location)
}
```

Having access to the route location means I can check if the action is `PUSH`, and decide if I need to actually do an ajax request, or take the existing data from `window.__ASYNC_PROPS__`. This may need more functionality if we want this library to grab the window object for you if you return false or something from the function. This could help solve: https://github.com/rackt/async-props/issues/28#issuecomment-170156687
