### PR TITLE
fix loading props twice in isomorphic apps

### DIFF
--- a/modules/AsyncProps.js
+++ b/modules/AsyncProps.js
@@ -237,7 +237,9 @@ class AsyncProps extends React.Component {
 
   componentDidMount() {
     const { components, params, location } = this.props
-    this.loadAsyncProps(components, params, location)
+    // only load props when we did not got any data from the server-side rendering
+    if(!this.state.propsAndComponents)
+      this.loadAsyncProps(components, params, location)
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
`this.state.propsAndComponents` is already hyrated with the necessary data so we don't have to load the props for a second time. only when the app is rendered on the server side and `window.__ASYNC_PROPS__` is set.
