### PR TITLE
updated to babel 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,7 @@
 {
-  "stage": 0,
-  "loose": "all",
+  "presets": [
+    "es2015",
+    "stage-0",
+    "react"
+  ]
 }
-

--- a/example/app.js
+++ b/example/app.js
@@ -11,7 +11,7 @@ class App extends React.Component {
     fetchContacts((err, contacts) => {
       cb(null, { contacts })
     })
-  }
+  };
 
   // Feel free to have your own opinion here: AsyncProps sends a prop
   // `reloadAsyncProps` to allow your app to reload props for a component
@@ -22,13 +22,13 @@ class App extends React.Component {
   // etc.
   static childContextTypes = {
     reloadContacts: React.PropTypes.func
-  }
+  };
 
   getChildContext() {
     return {
       reloadContacts: () => this.props.reloadAsyncProps()
     }
-  }
+  };
 
   render() {
     // props.loading comes from AsyncProps
@@ -52,7 +52,7 @@ class App extends React.Component {
         {this.props.children}
       </div>
     )
-  }
+  };
 
 }
 
@@ -62,11 +62,11 @@ class Contact extends React.Component {
     fetchContact(params.contactId, (err, contact) => {
       cb(null, { contact })
     })
-  }
+  };
 
   static contextTypes = {
     reloadContacts: React.PropTypes.func.isRequired
-  }
+  };
 
   delete() {
     deleteContact(this.props.contact.id, (err) => {
@@ -78,7 +78,7 @@ class Contact extends React.Component {
         this.props.history.pushState(null, '/')
       }
     })
-  }
+  };
 
   render() {
     const { contact } = this.props
@@ -89,14 +89,14 @@ class Contact extends React.Component {
         <button onClick={() => this.delete()}>Delete</button>
       </div>
     )
-  }
+  };
 }
 
 class New extends React.Component {
 
   static contextTypes = {
     reloadContacts: React.PropTypes.func.isRequired
-  }
+  };
 
   submit(e) {
     e.preventDefault()
@@ -105,7 +105,7 @@ class New extends React.Component {
       this.context.reloadContacts()
       this.props.history.pushState(null, `/${savedContact.id}`)
     })
-  }
+  };
 
   render() {
     return (
@@ -121,7 +121,7 @@ class New extends React.Component {
         </p>
       </form>
     )
-  }
+  };
 
 }
 
@@ -156,4 +156,3 @@ render((
     </Route>
   </Router>
 ), document.getElementById('app'))
-

--- a/modules/AsyncProps.js
+++ b/modules/AsyncProps.js
@@ -145,11 +145,11 @@ class AsyncPropsContainer extends React.Component {
   static propTypes = {
     Component: func.isRequired,
     routerProps: object.isRequired
-  }
+  };
 
   static contextTypes = {
     asyncProps: object.isRequired
-  }
+  };
 
   componentWillReceiveProps(nextProps) {
     const paramsChanged = !shallowEqual(nextProps.routerProps.routeParams,
@@ -157,7 +157,7 @@ class AsyncPropsContainer extends React.Component {
     if (paramsChanged) {
       this.context.asyncProps.reloadComponent(nextProps.Component)
     }
-  }
+  };
 
   render() {
     const { Component, routerProps, ...props } = this.props
@@ -173,7 +173,7 @@ class AsyncPropsContainer extends React.Component {
         loading={loading}
       />
     )
-  }
+  };
 
 }
 
@@ -181,7 +181,7 @@ class AsyncProps extends React.Component {
 
   static childContextTypes = {
     asyncProps: object
-  }
+  };
 
   static propTypes = {
     components: array.isRequired,
@@ -193,7 +193,7 @@ class AsyncProps extends React.Component {
     // server rendering
     propsArray: array,
     componentsArray: array
-  }
+  };
 
   static defaultProps = {
     onError(err) {
@@ -207,7 +207,7 @@ class AsyncProps extends React.Component {
     render(props) {
       return <RouterContext {...props} createElement={createElement}/>
     }
-  }
+  };
 
   constructor(props, context) {
     super(props, context)
@@ -220,7 +220,7 @@ class AsyncProps extends React.Component {
         { propsArray, componentsArray } :
         hydrate(props)
     }
-  }
+  };
 
   getChildContext() {
     const { loading, propsAndComponents } = this.state
@@ -233,12 +233,12 @@ class AsyncProps extends React.Component {
         }
       }
     }
-  }
+  };
 
   componentDidMount() {
     const { components, params, location } = this.props
     this.loadAsyncProps(components, params, location)
-  }
+  };
 
   componentWillReceiveProps(nextProps) {
     const routeChanged = nextProps.location !== this.props.location
@@ -260,7 +260,7 @@ class AsyncProps extends React.Component {
 
     if (components.length > 0)
       this.loadAsyncProps(components, nextProps.params, nextProps.location)
-  }
+  };
 
   handleError(cb) {
     return (err, ...args) => {
@@ -269,11 +269,11 @@ class AsyncProps extends React.Component {
       else
         cb(null, ...args)
     }
-  }
+  };
 
   componentWillUnmount() {
     this._unmounted = true
-  }
+  };
 
   loadAsyncProps(components, params, location, options) {
     this.setState({
@@ -305,12 +305,12 @@ class AsyncProps extends React.Component {
         }
       })
     )
-  }
+  };
 
   reloadComponent(Component) {
     const { params } = this.props
     this.loadAsyncProps([ Component ], params, null, { force: true })
-  }
+  };
 
   render() {
     const { propsAndComponents } = this.state
@@ -321,7 +321,7 @@ class AsyncProps extends React.Component {
       const props = this.state.loading ? this.state.prevProps : this.props
       return this.props.render(props)
     }
-  }
+  };
 
 }
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "bugs": "https://github.com/rackt/async-props/issues",
   "scripts": {
-    "build": "babel ./modules --stage 0 --loose all -d lib --ignore '__tests__'",
+    "build": "babel ./modules -d lib",
     "build-umd": "NODE_ENV=production webpack modules/AsyncProps.js umd/AsyncProps.js",
     "build-min": "NODE_ENV=production webpack -p modules/AsyncProps.js umd/AsyncProps.min.js",
     "lint": "eslint modules",

--- a/package.json
+++ b/package.json
@@ -26,10 +26,13 @@
     "react-router": "2.0.0-rc4"
   },
   "devDependencies": {
-    "babel": "^5.8.34",
-    "babel-core": "^5.8.34",
-    "babel-eslint": "^3.1.23",
-    "babel-loader": "^5.4.0",
+    "babel-cli": "^6.4.0",
+    "babel-core": "^6.4.0",
+    "babel-eslint": "^5.0.0-beta6",
+    "babel-loader": "^6.2.1",
+    "babel-preset-es2015": "^6.3.13",
+    "babel-preset-react": "^6.3.13",
+    "babel-preset-stage-0": "^6.3.13",
     "eslint": "1.4.1",
     "eslint-config-rackt": "1.0.0",
     "eslint-plugin-react": "3.3.2",


### PR DESCRIPTION
I tried to install async-props in my package where babel 6 is used in the root. It always tries to use the already installed babel 6 in the node_modules with the .babelrc which is for babel 5... Building always failed
