### PR TITLE
Implements the core async bit in Rx.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "license": "MIT",
   "peerDependencies": {
     "react": "0.14.x",
-    "react-router": "2.0.0-rc4"
+    "react-router": "2.0.0-rc4",
+    "rxjs": "^5.0.0-beta.1"
   },
   "devDependencies": {
     "babel": "^5.8.34",


### PR DESCRIPTION
Saw [this comment](https://github.com/rackt/async-props/blob/master/modules/AsyncProps.js#L289) and figured I'd help out. This PR reimplements the internal `loadAsyncProps` method with Observables, so calls to `reloadAsyncProps` or `reloadComponent` will cancel the pending operation and switch to the latest one.
