### PR TITLE
Only reload components down from the pivot point

### DIFF
--- a/modules/AsyncProps.js
+++ b/modules/AsyncProps.js
@@ -1,12 +1,9 @@
 /*global __ASYNC_PROPS__*/
 import React from 'react'
 import RouterContext from 'react-router/lib/RouterContext'
+import { getParamNames } from 'react-router/lib/PatternUtils'
 
 const { array, func, object } = React.PropTypes
-
-function last(arr) {
-  return arr[arr.length - 1]
-}
 
 function eachComponents(components, iterator) {
   for (var i = 0, l = components.length; i < l; i++) {
@@ -77,34 +74,6 @@ function mergePropsAndComponents(current, changes) {
   return current
 }
 
-function arrayDiff(previous, next) {
-  var diff = []
-
-  for (var i = 0, l = next.length; i < l; i++)
-    if (previous.indexOf(next[i]) === -1)
-      diff.push(next[i])
-
-  return diff
-}
-
-function shallowEqual(a, b) {
-  var key
-  var ka = 0
-  var kb = 0
-
-  for (key in a) {
-    if (a.hasOwnProperty(key) && a[key] !== b[key])
-      return false
-    ka++
-  }
-
-  for (key in b)
-    if (b.hasOwnProperty(key))
-      kb++
-
-  return ka === kb
-}
-
 function createElement(Component, props) {
   if (Component.loadProps)
     return <AsyncPropsContainer Component={Component} routerProps={props}/>
@@ -149,14 +118,6 @@ class AsyncPropsContainer extends React.Component {
 
   static contextTypes = {
     asyncProps: object.isRequired
-  }
-
-  componentWillReceiveProps(nextProps) {
-    const paramsChanged = !shallowEqual(nextProps.routerProps.routeParams,
-                                        this.props.routerProps.routeParams)
-    if (paramsChanged) {
-      this.context.asyncProps.reloadComponent(nextProps.Component)
-    }
   }
 
   render() {
@@ -245,16 +206,18 @@ class AsyncProps extends React.Component {
     if (!routeChanged)
       return
 
-    const oldComponents = filterAndFlattenComponents(this.props.components)
-    const newComponents = filterAndFlattenComponents(nextProps.components)
-    let components = arrayDiff(oldComponents, newComponents)
-
-    if (components.length === 0) {
-      const sameComponents = shallowEqual(oldComponents, newComponents)
-      if (sameComponents) {
-        const paramsChanged = !shallowEqual(nextProps.params, this.props.params)
-        if (paramsChanged)
-          components = [ last(newComponents) ]
+    let components = []
+    let pivoted = false
+    for (let i = 0; i < nextProps.routes.length; i++) {
+      const path = nextProps.routes[i].path
+      if (path) {
+        const params = getParamNames(path)
+        pivoted = pivoted || params.some(name => this.props.params[name] !== nextProps.params[name])
+      }
+      if (pivoted) {
+        const Component = nextProps.components[i]
+        if (Component.loadProps)
+          components.push(Component)
       }
     }
 

--- a/modules/AsyncProps.js
+++ b/modules/AsyncProps.js
@@ -209,16 +209,21 @@ class AsyncProps extends React.Component {
     let components = []
     let pivoted = false
     for (let i = 0; i < nextProps.routes.length; i++) {
-      const path = nextProps.routes[i].path
-      if (path) {
-        const params = getParamNames(path)
-        pivoted = pivoted || params.some(name => this.props.params[name] !== nextProps.params[name])
+      const component = nextProps.components[i]
+      if (!pivoted) {
+        const oldComponent = this.props.components[i]
+        if (component !== oldComponent) {
+          pivoted = true
+        } else {
+          const path = nextProps.routes[i].path
+          if (!path)
+            continue
+          const params = getParamNames(path)
+          pivoted = params.some(name => this.props.params[name] !== nextProps.params[name])
+        }
       }
-      if (pivoted) {
-        const Component = nextProps.components[i]
-        if (Component.loadProps)
-          components.push(Component)
-      }
+      if (pivoted && component.loadProps)
+        components.push(component)
     }
 
     if (components.length > 0)


### PR DESCRIPTION
Fixes loadProps being called twice or not at all in some cases.

It's impossible to know which components to call loadProps on without knowing what params they need. This patch assumes that loadProps on a component does not use the params of its children, which I think is a reasonable assumption. Without this (or explicitely specifying what params you want to listen to) the only thing you can do is refresh everything on every route change.

https://github.com/rackt/async-props/issues/28
