### PR TITLE
Make examples work with latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ app.get('*', (req, res) => {
   match({ routes, location: req.url }, (err, redirect, renderProps) => {
 
     // 1. load the props
-    loadPropsOnServer(renderProps, (err, asyncProps, scriptTag) => {
+    loadPropsOnServer(renderProps, {}, (err, asyncProps, scriptTag) => {
 
       // 2. use `AsyncProps` instead of `RoutingContext` and pass it
       //    `renderProps` and `asyncProps`

--- a/example/api.js
+++ b/example/api.js
@@ -1,7 +1,7 @@
 localStorage.token = localStorage.token || (Date.now()*Math.random())
 
-//const API = 'http://addressbook-api.herokuapp.com'
-const API = 'http://localhost:3000'
+const API = 'http://addressbook-api.herokuapp.com'
+//const API = 'http://localhost:3000'
 
 function setToken(req) {
   req.setRequestHeader('authorization', localStorage.token)

--- a/example/app.js
+++ b/example/app.js
@@ -58,7 +58,7 @@ class App extends React.Component {
 
 class Contact extends React.Component {
 
-  static loadProps(params, cb) {
+  static loadProps({params}, cb) {
     fetchContact(params.contactId, (err, contact) => {
       cb(null, { contact })
     })


### PR DESCRIPTION
The example and the README is not currently up to date with the latest API. This PR fixes that.

However, I'm not sure if this is the API you intended - `loadPropsOnServer` now has a mandatory `loadContext` argument, but `loadProps` does not.

This means you'll have to do this in your `loadProps` methods:

``` js
loadProps(params, cb) {
  loadSomethingAsync(params.params.someParam, cb)
}
```

Of course, you can "get around" this by using ES6:

``` js
loadProps({params}, cb) {
  loadSomethingAsync(params.someParam, cb)
}
```

But as I said, wasn't sure if this was what you intended, since the examples were not updated... Thoughts?
