### PR TITLE
fix loadPropsOnServer params

### DIFF
--- a/modules/AsyncProps.js
+++ b/modules/AsyncProps.js
@@ -94,6 +94,10 @@ function createElement(Component, props) {
 }
 
 export function loadPropsOnServer({ components, params }, loadContext, cb) {
+  if (typeof loadContext === 'function') {
+    cb = loadContext
+    loadContext = {}
+  }
   loadAsyncProps({
     components: filterAndFlattenComponents(components),
     params,


### PR DESCRIPTION
### Context

This pull request fix "Is the loadPropsOnServer example up-to-date? #63" and related to "https://github.com/ryanflorence/async-props/pull/60"
### Consideration

The `loadPropsOnServer` method takes in three params `({ components, params }, loadContext, cb)`, but from the readme example it only takes two and will cause a `cb is not a function` error for server side rendering.

``` JavaScript
// 1. load the props
    loadPropsOnServer(renderProps, (err, asyncProps, scriptTag) => {})
```

It could be fixed by add an empty `loadContext` object to the function, but the cleanest way could be to check the type of the `loadContext`, and this way can make the function work for both 2 and 3 params.

``` JavaScript
if (typeof loadContext === 'function') {
   cb = loadContext
   loadContext = {}
}
```
