### PR TITLE
allow React Router 3.0 alphas that are working

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "peerDependencies": {
     "react": "*",
-    "react-router": "^2.0.1"
+    "react-router": "^2.0.1 || 3.0.0-alpha.1 || 3.0.0-alpha.3"
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",


### PR DESCRIPTION
I've tested this with alpha 1 and 3 of React Router 3.0.

Without this version allowance when using RR3 you'll get the error,

```
npm ERR! peer invalid: react-router@^2.0.1, required by async-props@0.3.2
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ryanflorence/async-props/72)

<!-- Reviewable:end -->
